### PR TITLE
fix: create loop state file so autonomous loop actually activates

### DIFF
--- a/commands/ralph-init.md
+++ b/commands/ralph-init.md
@@ -19,16 +19,16 @@ Set up a new Ralph Marketer copywriting project in the current directory.
 
 ```bash
 # Create directories
-mkdir -p scripts/ralph content/{drafts,published} data src/{db,content}
+mkdir -p scripts/ralph content/{drafts,published} data scripts/src/{db,content}
 
 # Copy database scripts from plugin
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
-cp "$PLUGIN_ROOT/scripts/src/db/init.js" src/db/
-cp "$PLUGIN_ROOT/scripts/src/db/seed.js" src/db/
-cp "$PLUGIN_ROOT/scripts/src/db/status.js" src/db/
-cp "$PLUGIN_ROOT/scripts/src/db/query.js" src/db/
-cp "$PLUGIN_ROOT/scripts/src/content/list.js" src/content/
-cp "$PLUGIN_ROOT/scripts/src/test.js" src/
+cp "$PLUGIN_ROOT/scripts/src/db/init.js" scripts/src/db/
+cp "$PLUGIN_ROOT/scripts/src/db/seed.js" scripts/src/db/
+cp "$PLUGIN_ROOT/scripts/src/db/status.js" scripts/src/db/
+cp "$PLUGIN_ROOT/scripts/src/db/query.js" scripts/src/db/
+cp "$PLUGIN_ROOT/scripts/src/content/list.js" scripts/src/content/
+cp "$PLUGIN_ROOT/scripts/src/test.js" scripts/src/
 
 # Copy Ralph templates
 cp "$PLUGIN_ROOT/templates/prd.json" scripts/ralph/

--- a/commands/ralph-marketer.md
+++ b/commands/ralph-marketer.md
@@ -78,6 +78,29 @@ $ARGUMENTS
 - `--max-iterations <n>`: Stop after N iterations (default: unlimited)
 - `--completion-promise <text>`: Custom completion signal (default: "COMPLETE")
 
+## Initialize Loop State
+
+Before starting your first iteration, create the loop state file so the stop hook can manage iterations:
+
+```bash
+# Parse arguments
+ARGS="$ARGUMENTS"
+MAX_ITER=$(echo "$ARGS" | grep -oP '(?<=--max-iterations )\d+' || echo "999999")
+PROMISE=$(echo "$ARGS" | grep -oP '(?<=--completion-promise )\S+' || echo "COMPLETE")
+
+# Create .claude directory if it doesn't exist
+mkdir -p .claude
+
+# Write loop state file
+cat > .claude/ralph-marketer-loop.local.md << STATEOF
+---
+iteration: 0
+max_iterations: $MAX_ITER
+completion_promise: $PROMISE
+---
+STATEOF
+```
+
 ## Begin
 
 Read the PRD. Find your next task. Ship great content.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug: Autonomous loop never activates

### Problem 1 — Missing loop state file creation (`commands/ralph-marketer.md`)

`stop-hook.sh` (line 21) checks for `.claude/ralph-marketer-loop.local.md` before doing anything:

```bash
if [ ! -f "$LOOP_STATE_FILE" ]; then
  exit 0  # allow exit — no loop running
fi
```

Nothing in the plugin ever creates this file. As a result, the stop hook always falls through to `exit 0`, Claude terminates after its first pass, and the autonomous-loop feature never runs. `ralph-cancel.md` also has nothing to delete.

**Fix:** Added an "Initialize Loop State" section to `ralph-marketer.md` with a bash snippet that:
- Parses `--max-iterations` and `--completion-promise` from `$ARGUMENTS`
- Creates `.claude/` if needed
- Writes the state file with the frontmatter keys (`iteration`, `max_iterations`, `completion_promise`) that `stop-hook.sh` reads

### Problem 2 — Wrong copy destination in `/ralph-init` (`commands/ralph-init.md`)

`ralph-init.md` copies scripts into `src/{db,content}/` and `src/test.js`, but `package.json` references all of these under `scripts/src/`:

```json
"db:init": "node scripts/src/db/init.js",
"test":    "node scripts/src/test.js"
```

After running `/ralph-init`, `npm test` and all `db:*` scripts fail with "module not found" because the files land in the wrong directory.

**Fix:** Changed the `mkdir` target and all `cp` destinations from `src/` to `scripts/src/` in the init bash block, matching the paths in `package.json`.

## Impact

Both issues together mean: after a fresh `/ralph-init` + `/ralph-marketer`, the `npm test` step fails on the first iteration *and* the loop exits immediately rather than continuing autonomously. The plugin's headline feature doesn't work out of the box.