### PR TITLE
fix: prevent JSON and regex injection in stop-hook.sh

### DIFF
--- a/hooks/stop-hook.sh
+++ b/hooks/stop-hook.sh
@@ -44,7 +44,7 @@ LAST_OUTPUT=$(echo "$INPUT" | jq -r '.transcript[-1].content // ""' 2>/dev/null 
 
 # Check for completion promise
 if [ -n "$COMPLETION_PROMISE" ]; then
-  if echo "$LAST_OUTPUT" | grep -q "<promise>$COMPLETION_PROMISE</promise>"; then
+  if echo "$LAST_OUTPUT" | grep -qF "<promise>${COMPLETION_PROMISE}</promise>"; then
     # Completion detected! Clean up and exit
     rm -f "$LOOP_STATE_FILE"
     echo '{"decision": "allow", "message": "Ralph loop completed successfully!"}'
@@ -93,9 +93,5 @@ When ALL tasks are complete, output: <promise>${COMPLETION_PROMISE:-COMPLETE}</p
 $PROMPT"
 
 # Return the block decision with the new prompt
-cat << EOF
-{
-  "decision": "block",
-  "message": "$SYSTEM_MSG"
-}
-EOF
+jq -n --arg decision "block" --arg message "$SYSTEM_MSG" \
+  '{decision: $decision, message: $message}'


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Two input-handling bugs in `hooks/stop-hook.sh`

### Fix 1 — Malformed JSON output when prompt contains quotes or newlines (Medium)

**Lines 96–101:** `$SYSTEM_MSG` was interpolated directly into a shell heredoc. `$SYSTEM_MSG` embeds `$PROMPT`, which is read from `scripts/ralph/prompt.md`. Any double-quote or newline in that file produces invalid JSON. The Claude Code stop-hook mechanism parses this output as JSON; a parse failure causes the hook to be silently ignored, allowing Claude to exit when it should be blocked.

**Fix:** Replaced the heredoc with `jq -n --arg`, which handles all necessary escaping.

### Fix 2 — Regex metacharacters in completion-promise break matching (Medium)

**Line 47:** `$COMPLETION_PROMISE` was passed as an unquoted grep regex. A custom `--completion-promise` value containing `.`, `*`, or `[` would change matching semantics — e.g. `DONE.v1` would match `<promise>DONExv1</promise>` since `.` is a regex wildcard.

**Fix:** Added `-F` for fixed-string matching and braced the variable.

Both fixes are backwards-compatible one-liners with no behaviour change for well-formed inputs.