### PR TITLE
fix: pin better-sqlite3 to exact version (11.10.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "better-sqlite3": "^11.0.0"
+    "better-sqlite3": "11.10.0"
   }
 }


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug: Unpinned dependency allows silent upgrades

`package.json` declares `"better-sqlite3": "^11.0.0"`. The caret range allows `npm install` to silently upgrade to any future `11.x.x` release — including releases that introduce breaking changes or (in a worst-case supply-chain scenario) malicious code.

`package-lock.json` already records the resolved version as `11.10.0`. This PR pins `package.json` to match, making installs deterministic without requiring any change to the lockfile.

**Before:** `"better-sqlite3": "^11.0.0"` — accepts any 11.x.x
**After:**  `"better-sqlite3": "11.10.0"` — exact version, matches lockfile

This is a low-risk, one-line change with no functional impact on current installs.